### PR TITLE
Dns-Services

### DIFF
--- a/DNS-Service/configurar-reenviadores.ps1
+++ b/DNS-Service/configurar-reenviadores.ps1
@@ -1,0 +1,9 @@
+# Configurar reenviadores para consultas externas
+
+# Configurar los reenviadores a los servidores DNS públicos de Google
+dnscmd /ResetForwarders 8.8.8.8 8.8.4.4
+
+# Nota: Para verificar la configuración, use nslookup desde otra máquina en la red
+# Ejemplo:
+# nslookup servidor.horchata.sv
+# nslookup 172.16.0.2

--- a/DNS-Service/configurar-zona-directa-ipv4.ps1
+++ b/DNS-Service/configurar-zona-directa-ipv4.ps1
@@ -1,0 +1,10 @@
+# Configurar zona directa IPv4
+
+# Agregar registros A (IPv4)
+dnscmd /RecordAdd horchata.sv servidor A 172.16.0.2
+dnscmd /RecordAdd horchata.sv servicio-web A 172.16.0.2
+dnscmd /RecordAdd horchata.sv anfitrion A 172.16.0.4
+dnscmd /RecordAdd horchata.sv pineda A 172.16.0.21
+dnscmd /RecordAdd horchata.sv martin A 172.16.0.22
+dnscmd /RecordAdd horchata.sv javi A 172.16.0.23
+dnscmd /RecordAdd horchata.sv marcelo A 172.16.0.24

--- a/DNS-Service/configurar-zona-directa-ipv6.ps1
+++ b/DNS-Service/configurar-zona-directa-ipv6.ps1
@@ -1,0 +1,10 @@
+# Configurar zona directa IPv6
+
+# Agregar registros AAAA (IPv6)
+dnscmd /RecordAdd horchata.sv servidor AAAA 2001:DB8:DEA:B::2
+dnscmd /RecordAdd horchata.sv servicio-web AAAA 2001:DB8:DEA:B::2
+dnscmd /RecordAdd horchata.sv anfitrion AAAA 2001:DB8:DEA:B::4
+dnscmd /RecordAdd horchata.sv pineda AAAA 2001:DB8:DEA:B::21
+dnscmd /RecordAdd horchata.sv martin AAAA 2001:DB8:DEA:B::22
+dnscmd /RecordAdd horchata.sv javi AAAA 2001:DB8:DEA:B::23
+dnscmd /RecordAdd horchata.sv oscar AAAA 2001:DB8:DEA:B::24

--- a/DNS-Service/configurar-zona-directa.ps1
+++ b/DNS-Service/configurar-zona-directa.ps1
@@ -1,0 +1,4 @@
+# Configurar la zona directa (maestra)
+
+# Crear la zona maestra para el dominio horchata.sv
+dnscmd /ZoneAdd horchata.sv /Primary

--- a/DNS-Service/configurar-zona-inversa-ipv4.ps1
+++ b/DNS-Service/configurar-zona-inversa-ipv4.ps1
@@ -1,0 +1,12 @@
+# Configurar zona inversa IPv4
+
+# Crear la zona inversa para la subred 172.16.0.0/24
+dnscmd /ZoneAdd 0.16.172.in-addr.arpa /Primary
+
+# Agregar registros PTR para IPv4
+dnscmd /RecordAdd 0.16.172.in-addr.arpa 2 PTR servidor.horchata.sv
+dnscmd /RecordAdd 0.16.172.in-addr.arpa 4 PTR anfitrion.horchata.sv
+dnscmd /RecordAdd 0.16.172.in-addr.arpa 21 PTR pineda.horchata.sv
+dnscmd /RecordAdd 0.16.172.in-addr.arpa 22 PTR martin.horchata.sv
+dnscmd /RecordAdd 0.16.172.in-addr.arpa 23 PTR javi.horchata.sv
+dnscmd /RecordAdd 0.16.172.in-addr.arpa 24 PTR marcelo.horchata.sv

--- a/DNS-Service/configurar-zona-inversa-ipv6.ps1
+++ b/DNS-Service/configurar-zona-inversa-ipv6.ps1
@@ -1,0 +1,12 @@
+# Configurar zona inversa IPv6
+
+# Crear la zona inversa para la red IPv6 2001:DB8:DEA:B::/64
+dnscmd /ZoneAdd B.EA.D.D.B.0.1.0.0.2.ip6.arpa /Primary
+
+# Agregar registros PTR para IPv6
+dnscmd /RecordAdd B.EA.D.D.B.0.1.0.0.2.ip6.arpa 2 PTR servidor.horchata.sv
+dnscmd /RecordAdd B.EA.D.D.B.0.1.0.0.2.ip6.arpa 4 PTR anfitrion.horchata.sv
+dnscmd /RecordAdd B.EA.D.D.B.0.1.0.0.2.ip6.arpa 21 PTR pineda.horchata.sv
+dnscmd /RecordAdd B.EA.D.D.B.0.1.0.0.2.ip6.arpa 22 PTR martin.horchata.sv
+dnscmd /RecordAdd B.EA.D.D.B.0.1.0.0.2.ip6.arpa 23 PTR javi.horchata.sv
+dnscmd /RecordAdd B.EA.D.D.B.0.1.0.0.2.ip6.arpa 24 PTR oscar.horchata.sv

--- a/DNS-Service/instalar-dns.ps1
+++ b/DNS-Service/instalar-dns.ps1
@@ -1,0 +1,10 @@
+# Instalar el rol de DNS
+
+# Instalar el rol de DNS con herramientas de administración
+Install-WindowsFeature DNS -IncludeManagementTools
+
+# Iniciar el servicio DNS
+Start-Service DNS
+
+# Configurar el servicio DNS para iniciarse automáticamente
+Set-Service -Name DNS -StartupType Automatic


### PR DESCRIPTION
This pull request includes several PowerShell scripts for configuring DNS services. The changes cover setting up forwarders, direct and reverse zones for both IPv4 and IPv6, and installing the DNS role with management tools.

DNS Configuration:

* [`DNS-Service/configurar-reenviadores.ps1`](diffhunk://#diff-58437c8f3e3a08411449511ea01d95a80f810c46469f7c87ee54ba044ec0351aR1-R9): Configured forwarders to Google's public DNS servers.
* [`DNS-Service/configurar-zona-directa.ps1`](diffhunk://#diff-3633a2ad77c54bf76f7e9ba153ba913ceb4f1770c07427e7c7d2b42ae6e40e55R1-R4): Created the primary zone for the domain `horchata.sv`.

IPv4 Zone Configuration:

* [`DNS-Service/configurar-zona-directa-ipv4.ps1`](diffhunk://#diff-1d53d306e41b713b328d0602cea5b4332f25088595e6d7f3b4e622499b01616fR1-R10): Added A records for various hosts in the `horchata.sv` domain.
* [`DNS-Service/configurar-zona-inversa-ipv4.ps1`](diffhunk://#diff-f8bcff01daceab9ca3b2750630b341a9f8fb9bb1011fa68ae8213e32ba8be2bfR1-R12): Created a reverse zone for the `172.16.0.0/24` subnet and added PTR records.

IPv6 Zone Configuration:

* [`DNS-Service/configurar-zona-directa-ipv6.ps1`](diffhunk://#diff-1898dd8a1e7be80664df165717e63f5bddac9fd5794deb2ef4f30b64d0335918R1-R10): Added AAAA records for various hosts in the `horchata.sv` domain.
* [`DNS-Service/configurar-zona-inversa-ipv6.ps1`](diffhunk://#diff-fc3b23a7f88757d1d1737bbc598659af04119506d238828123466c4cbf162556R1-R12): Created a reverse zone for the `2001:DB8:DEA:B::/64` network and added PTR records.

DNS Role Installation:

* [`DNS-Service/instalar-dns.ps1`](diffhunk://#diff-7ea17cfb00e134de89e4527c43c653faafdc476175d5be2ab7474c926bc61d23R1-R10): Installed the DNS role with management tools, started the DNS service, and set it to start automatically.